### PR TITLE
Fix satomi issues for token-swap client

### DIFF
--- a/token-swap/js/src/index.ts
+++ b/token-swap/js/src/index.ts
@@ -409,7 +409,7 @@ export class TokenSwap {
       SystemProgram.createAccount({
         fromPubkey: payer.publicKey,
         newAccountPubkey: tokenSwapAccount.publicKey,
-        satomis: balanceNeeded,
+        lamports: balanceNeeded,
         space: TokenSwapLayout.span,
         programId: swapProgramId,
       }),

--- a/token-swap/js/test/token-swap-test.ts
+++ b/token-swap/js/test/token-swap-test.ts
@@ -9,7 +9,7 @@ import {
 import {AccountLayout, Token, TOKEN_PROGRAM_ID} from '@solana/spl-token';
 
 import {TokenSwap, CurveType, TOKEN_SWAP_PROGRAM_ID} from '../src';
-import {newAccountWithSatomis} from '../src/util/new-account-with-satomis';
+import {newAccountWithSatomis} from '../src/util/new-account-with-lamports';
 import {sleep} from '../src/util/sleep';
 import {Numberu64} from '../src';
 
@@ -375,7 +375,7 @@ export async function createAccountAndSwapAtomic(): Promise<void> {
     SystemProgram.createAccount({
       fromPubkey: owner.publicKey,
       newAccountPubkey: newAccount.publicKey,
-      satomis: balanceNeeded,
+      lamports: balanceNeeded,
       space: AccountLayout.span,
       programId: mintB.programId,
     }),


### PR DESCRIPTION
Got node.js errors during the token-swap tests. Fixed satomi fields in the Solana Web3.js lib calls.